### PR TITLE
Create env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ npm-debug.log
 # we ignore priv/static. You may want to comment
 # this depending on your deployment strategy.
 /priv/static/
+
+config/dev.secret.exs

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -74,3 +74,5 @@ config :phoenix, :stacktrace_depth, 20
 
 # Initialize plugs at runtime for faster development compilation
 config :phoenix, :plug_init_mode, :runtime
+
+import_config "dev.secret.exs"

--- a/config/dev.secret.exs.example
+++ b/config/dev.secret.exs.example
@@ -1,0 +1,8 @@
+use Mix.Config
+
+config :star_track, StarTrack.Repo,
+  username: "postgres",
+  password: "postgres",
+  database: "star_track_dev",
+  hostname: "localhost",
+  port: 5432

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,3 +16,5 @@ config :star_track, StarTrackWeb.Endpoint,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+
+import_config "dev.secret.exs"


### PR DESCRIPTION
This allows us to change the database connection according to our needs without affecting one another. It works basically like our .env.example and .env on Rails projects: create a dev.secrets.exs with your config and you are good to go.

Here is mine:

```exs
use Mix.Config

config :vdeveganca, Vdeveganca.Repo,
  username: "postgres",
  password: "",
  port: 32768
```